### PR TITLE
Terminate RSM drivers when session expires

### DIFF
--- a/pkg/atomix/storage/protocol/rsm/manager.go
+++ b/pkg/atomix/storage/protocol/rsm/manager.go
@@ -283,7 +283,7 @@ func (m *primitiveServiceManager) command(request *CommandRequest, stream stream
 func (m *primitiveServiceManager) sessionCommand(request *SessionCommandRequest, stream streams.WriteStream) {
 	session, ok := m.sessions[request.SessionID]
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		stream.Close()
 		return
 	}
@@ -328,7 +328,7 @@ func (m *primitiveServiceManager) sessionCommand(request *SessionCommandRequest,
 func (m *primitiveServiceManager) serviceCommand(request *ServiceCommandRequest, session *primitiveSession, stream streams.WriteStream) {
 	service, ok := session.getService(request.ServiceID)
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		stream.Close()
 		return
 	}
@@ -371,7 +371,7 @@ func (m *primitiveServiceManager) closeService(request *CloseServiceRequest, ses
 	defer stream.Close()
 	service, ok := session.getService(request.ServiceID)
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		return
 	}
 	if err := service.close(); err != nil {
@@ -385,7 +385,7 @@ func (m *primitiveServiceManager) keepAlive(request *KeepAliveRequest, stream st
 	defer stream.Close()
 	session, ok := m.sessions[request.SessionID]
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		return
 	}
 
@@ -435,7 +435,7 @@ func (m *primitiveServiceManager) closeSession(request *CloseSessionRequest, str
 	defer stream.Close()
 	session, ok := m.sessions[request.SessionID]
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		return
 	}
 	if err := session.close(); err != nil {
@@ -483,7 +483,7 @@ func (m *primitiveServiceManager) indexQuery(request *QueryRequest, stream strea
 func (m *primitiveServiceManager) sessionQuery(request *SessionQueryRequest, stream streams.WriteStream) {
 	session, ok := m.sessions[request.SessionID]
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		stream.Close()
 		return
 	}
@@ -506,7 +506,7 @@ func (m *primitiveServiceManager) sessionQuery(request *SessionQueryRequest, str
 func (m *primitiveServiceManager) serviceQuery(request *ServiceQueryRequest, session *primitiveSession, stream streams.WriteStream) {
 	service, ok := session.getService(request.ServiceID)
 	if !ok {
-		stream.Error(errors.NewNotFound("session not found"))
+		stream.Error(errors.NewFault("session not found"))
 		stream.Close()
 		return
 	}


### PR DESCRIPTION
This PR fixes bugs in the replicated state machine driver and services handling of errors. A new `Fault` error type is added to the `errors` package and used to indicate that a session cannot be found, which implies potential data loss. When a proxy receives a `Fault` error, the driver process is exited so that it can be restarted by Kubernetes.